### PR TITLE
fix port params bug

### DIFF
--- a/src/app/params/check.go
+++ b/src/app/params/check.go
@@ -65,7 +65,7 @@ func checkParams() {
 }
 
 func checkIntsParam(v string) bool {
-	matched, err := regexp.MatchString("^((?:[0-9])+(?:-[0-9]+)?)(?:,(?:[0-9])+-(?:[0-9])+)*$", v)
+	matched, err := regexp.MatchString("^((?:[0-9])+(?:-[0-9]+)?)(?:,((?:[0-9])+(?:-[0-9]+)?))*$", v)
 	if err != nil {
 		return false
 	}


### PR DESCRIPTION
修复port传参数的正则bug,现在完美测试通过 ./kscan -p "80,8081,81-83,877,22-23" -t http://www.baidu.com
![image](https://user-images.githubusercontent.com/7765655/114390425-d7219980-9bc8-11eb-90f8-cd98fa958d36.png)
