### PR TITLE
修复异常未退出导致的崩溃

### DIFF
--- a/lib/fofa/fofa.go
+++ b/lib/fofa/fofa.go
@@ -79,14 +79,17 @@ func (f *Fofa) Search(keyword string) (int, []Result) {
 	resp, err := http.DefaultClient.Do(req)
 	if err != nil {
 		logger.Println(err)
+		return 0, nil
 	}
 	body, err := ioutil.ReadAll(resp.Body)
 	if err != nil {
 		logger.Println(err)
+		return 0, nil
 	}
 	var responseJson ResponseJson
 	if err = json.Unmarshal(body, &responseJson); err != nil {
 		logger.Println(body, err)
+		return 0, nil
 	}
 	r := f.makeResult(responseJson)
 	f.results = append(f.results, r...)


### PR DESCRIPTION
```
panic: runtime error: invalid memory address or nil pointer dereference
[signal SIGSEGV: segmentation violation code=0x1 addr=0x40 pc=0xa8cb10]

goroutine 1 [running]:
kscan/lib/fofa.(*Fofa).Search(0xc00069b9e0, {0x7ffca1a0e775, 0x2f})
        kscan/lib/fofa/fofa.go:83 +0x730
kscan/core/fofa.Run()
        kscan/core/fofa/fofa.go:32 +0xd4
main.InitFofa()
        ./kscan.go:276 +0x15e
main.main()
        ./kscan.go:166 +0x2be
```
![image](https://user-images.githubusercontent.com/44518337/170612410-7b6b1295-0c9a-4398-88d5-a036c84746e0.png)
