### PR TITLE
[*]修复 Start 函数导致向已关闭的 channel 存放数据导致的 panic 问题

### DIFF
--- a/run/run.go
+++ b/run/run.go
@@ -41,6 +41,7 @@ func Start() {
 	}
 	slog.Println(slog.INFO, "所有扫描任务已下发完毕")
 	wg.Wait()
+	stop()
 }
 
 func pushTarget(expr string) {
@@ -387,8 +388,8 @@ func outputHandler(target, keyword string, m map[string]string) {
 	slog.Println(slog.DATA, printStr)
 
 	if jw := app.Setting.OutputJson; jw != nil {
-		m["target"] = target
-		m["keyword"] = keyword
+		sourceMap["target"] = target
+		sourceMap["keyword"] = keyword
 		jw.Push(sourceMap)
 	}
 }
@@ -464,6 +465,5 @@ func watchDog(wg *sync.WaitGroup) {
 		}
 		break
 	}
-	stop()
 	wg.Done()
 }


### PR DESCRIPTION
[fix] 修复，`panic: send on closed channel` 问题
问题原因：在扫描任务未下发完毕的时候调用了看门狗函数、导致看门狗函数以为任务已经全部执行完毕、关闭线程池、导致向已关闭的 channel 发送数据、导致程序 panic