### PR TITLE
fix: remove duplicate ports

### DIFF
--- a/app/type-config.go
+++ b/app/type-config.go
@@ -150,6 +150,18 @@ func (c *Config) loadPort() {
 	if len(c.Port) == 0 {
 		c.Port = TOP_1000[:400]
 	}
+
+	// port去重
+	avaliablePorts := []int{}
+	portsMap := map[int]byte{}
+	for _, p := range c.Port {
+		l := len(portsMap)
+		portsMap[p] = 0
+		if len(portsMap) != l {
+			avaliablePorts = append(avaliablePorts, p)
+		}
+	}
+	c.Port = avaliablePorts
 }
 
 func (c *Config) loadExcludedPort() {


### PR DESCRIPTION
指定端口扫描时，去除重复的端口