### PR TITLE
fix: remove duplicate ports

### DIFF
--- a/app/type-config.go
+++ b/app/type-config.go
@@ -150,6 +150,8 @@ func (c *Config) loadPort() {
 	if len(c.Port) == 0 {
 		c.Port = TOP_1000[:400]
 	}
+
+	c.Port = misc.RemoveDuplicateElement(c.Port)
 }
 
 func (c *Config) loadExcludedPort() {


### PR DESCRIPTION
扫描端口时，去掉重复的端口